### PR TITLE
Fix frr debian pkg build failure when frr is a submodule

### DIFF
--- a/tools/tarsource.sh
+++ b/tools/tarsource.sh
@@ -133,7 +133,7 @@ onexit() {
 trap onexit EXIT
 tmpdir="`mktemp -d -t frrtar.XXXXXX`"
 
-if test -d "$src/.git"; then
+if test -e "$src/.git"; then
 	commit="`git -C \"$src\" rev-parse \"${commit:-HEAD}\"`"
 
 	if $dirty; then


### PR DESCRIPTION
Signed-off-by: nikos <ntriantafillis@gmail.com>