### PR TITLE
4-byte ASN displayed incorrectly as signed int in 'show ip bgp peer-group'

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -11404,10 +11404,10 @@ static int bgp_show_one_peer_group(struct vty *vty, struct peer_group *group)
 	conf = group->conf;
 
 	if (conf->as_type == AS_SPECIFIED || conf->as_type == AS_EXTERNAL) {
-		vty_out(vty, "\nBGP peer-group %s, remote AS %d\n", group->name,
+		vty_out(vty, "\nBGP peer-group %s, remote AS %u\n", group->name,
 			conf->as);
 	} else if (conf->as_type == AS_INTERNAL) {
-		vty_out(vty, "\nBGP peer-group %s, remote AS %d\n", group->name,
+		vty_out(vty, "\nBGP peer-group %s, remote AS %u\n", group->name,
 			group->bgp->as);
 	} else {
 		vty_out(vty, "\nBGP peer-group %s\n", group->name);


### PR DESCRIPTION
Fixed display to print the remote ASN of peer-group in unsigned int format.

Before it showed like this:

SONiC# show ip bgp peer-group 4ByteASN 

BGP peer-group 4ByteASN, remote AS -55 <====== 4294967241 is the configured value
  Peer-group type is external 
  Configured address-families: IPv4 Unicast; 
  Peer-group members: 
    41.39.2.0 Established 

After the fix, it shows like this:

SONiC# show ip bgp peer-group 4ByteASN 

BGP peer-group 4ByteASN, remote AS 4294967241 
  Peer-group type is external 
  Configured address-families: IPv4 Unicast; 
  Peer-group members: 
    41.39.2.0 Established 