### PR TITLE
zebra: Add kernel level graceful restart

### DIFF
--- a/doc/user/zebra.rst
+++ b/doc/user/zebra.rst
@@ -27,6 +27,13 @@ Besides the common invocation options (:ref:`common-invocation-options`), the
 
    When zebra starts up, don't delete old self inserted routes.
 
+.. option:: -K TIME, --graceful_restart TIME
+
+   If this option is specified, the graceful restart time is TIME seconds.
+   Zebra, when started, will read in routes.  Those routes that Zebra
+   identifies that it was the originator of will be swept in TIME seconds.
+   If no time is specified then we will sweep those routes immediately.
+
 .. option:: -r, --retain
 
    When program terminates, do not flush routes installed by *zebra* from the

--- a/zebra/main.c
+++ b/zebra/main.c
@@ -77,6 +77,8 @@ int allow_delete = 0;
 /* Don't delete kernel route. */
 int keep_kernel_mode = 0;
 
+int graceful_restart;
+
 bool v6_rr_semantics = false;
 
 #ifdef HAVE_NETLINK
@@ -95,6 +97,7 @@ struct option longopts[] = {
 	{"label_socket", no_argument, NULL, 'l'},
 	{"retain", no_argument, NULL, 'r'},
 	{"vrfdefaultname", required_argument, NULL, 'o'},
+	{"graceful_restart", required_argument, NULL, 'K'},
 #ifdef HAVE_NETLINK
 	{"vrfwnetns", no_argument, NULL, 'n'},
 	{"nl-bufsize", required_argument, NULL, 's'},
@@ -264,13 +267,14 @@ int main(int argc, char **argv)
 	char *netlink_fuzzing = NULL;
 #endif /* HANDLE_NETLINK_FUZZING */
 
+	graceful_restart = 0;
 	vrf_configure_backend(VRF_BACKEND_VRF_LITE);
 	logicalrouter_configure_backend(LOGICALROUTER_BACKEND_NETNS);
 
 	frr_preinit(&zebra_di, argc, argv);
 
 	frr_opt_add(
-		"bakz:e:l:o:r"
+		"bakz:e:l:o:rK:"
 #ifdef HAVE_NETLINK
 		"s:n"
 #endif
@@ -282,24 +286,25 @@ int main(int argc, char **argv)
 #endif /* HANDLE_NETLINK_FUZZING */
 		,
 		longopts,
-		"  -b, --batch           Runs in batch mode\n"
-		"  -a, --allow_delete    Allow other processes to delete zebra routes\n"
-		"  -z, --socket          Set path of zebra socket\n"
-		"  -e, --ecmp            Specify ECMP to use.\n"
-		"  -l, --label_socket    Socket to external label manager\n"
-		"  -k, --keep_kernel     Don't delete old routes which were installed by zebra.\n"
-		"  -r, --retain          When program terminates, retain added route by zebra.\n"
-		"  -o, --vrfdefaultname  Set default VRF name.\n"
+		"  -b, --batch              Runs in batch mode\n"
+		"  -a, --allow_delete       Allow other processes to delete zebra routes\n"
+		"  -z, --socket             Set path of zebra socket\n"
+		"  -e, --ecmp               Specify ECMP to use.\n"
+		"  -l, --label_socket       Socket to external label manager\n"
+		"  -k, --keep_kernel        Don't delete old routes which were installed by zebra.\n"
+		"  -r, --retain             When program terminates, retain added route by zebra.\n"
+		"  -o, --vrfdefaultname     Set default VRF name.\n"
+		"  -K, --graceful_restart   Graceful restart at the kernel level, timer in seconds for expiration\n"
 #ifdef HAVE_NETLINK
-		"  -n, --vrfwnetns       Use NetNS as VRF backend\n"
-		"  -s, --nl-bufsize      Set netlink receive buffer size\n"
-		"      --v6-rr-semantics Use v6 RR semantics\n"
+		"  -n, --vrfwnetns          Use NetNS as VRF backend\n"
+		"  -s, --nl-bufsize         Set netlink receive buffer size\n"
+		"      --v6-rr-semantics    Use v6 RR semantics\n"
 #endif /* HAVE_NETLINK */
 #if defined(HANDLE_ZAPI_FUZZING)
-		"  -c <file>             Bypass normal startup and use this file for testing of zapi\n"
+		"  -c <file>                Bypass normal startup and use this file for testing of zapi\n"
 #endif /* HANDLE_ZAPI_FUZZING */
 #if defined(HANDLE_NETLINK_FUZZING)
-		"  -w <file>             Bypass normal startup and use this file for testing of netlink input\n"
+		"  -w <file>                Bypass normal startup and use this file for testing of netlink input\n"
 #endif /* HANDLE_NETLINK_FUZZING */
 	);
 
@@ -319,6 +324,10 @@ int main(int argc, char **argv)
 			allow_delete = 1;
 			break;
 		case 'k':
+			if (graceful_restart) {
+				zlog_err("Graceful Restart initiated, we cannot keep the existing kernel routes");
+				return 1;
+			}
 			keep_kernel_mode = 1;
 			break;
 		case 'e':
@@ -349,6 +358,13 @@ int main(int argc, char **argv)
 			break;
 		case 'r':
 			retain_mode = 1;
+			break;
+		case 'K':
+			if (keep_kernel_mode) {
+				zlog_err("Keep Kernel mode specified, graceful restart incompatible");
+				return 1;
+			}
+			graceful_restart = atoi(optarg);
 			break;
 #ifdef HAVE_NETLINK
 		case 's':
@@ -437,8 +453,10 @@ int main(int argc, char **argv)
 	*  will be equal to the current getpid(). To know about such routes,
 	* we have to have route_read() called before.
 	*/
+	zrouter.startup_time = monotime(NULL);
 	if (!keep_kernel_mode)
-		rib_sweep_route();
+		thread_add_timer(zrouter.master, rib_sweep_route,
+				 NULL, graceful_restart, NULL);
 
 	/* Needed for BSD routing socket. */
 	pid = getpid();

--- a/zebra/rib.h
+++ b/zebra/rib.h
@@ -351,7 +351,7 @@ extern struct route_entry *rib_lookup_ipv4(struct prefix_ipv4 *p,
 extern void rib_update(vrf_id_t vrf_id, rib_update_event_t event);
 extern void rib_update_table(struct route_table *table,
 			     rib_update_event_t event);
-extern void rib_sweep_route(void);
+extern int rib_sweep_route(struct thread *t);
 extern void rib_sweep_table(struct route_table *table);
 extern void rib_close_table(struct route_table *table);
 extern void rib_init(void);

--- a/zebra/zebra_router.h
+++ b/zebra/zebra_router.h
@@ -113,7 +113,16 @@ struct zebra_router {
 	 * The EVPN instance, if any
 	 */
 	struct zebra_vrf *evpn_vrf;
+
+	uint32_t multipath_num;
+
+	/*
+	 * Time for when we sweep the rib from old routes
+	 */
+	time_t startup_time;
 };
+
+#define GRACEFUL_RESTART_TIME 60
 
 extern struct zebra_router zrouter;
 


### PR DESCRIPTION
<Initial Code from Praveen Chaudhary>

Add the a `--graceful_restart X` flag to zebra start that
now creates a timer that pops in X seconds and will go
through and remove all routes that are older than startup.

If graceful_restart is not specified then we will just pop
a timer that cleans everything up immediately.

Signed-off-by: Praveen Chaudhary <pchaudhary@linkedin.com>
Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>