### PR TITLE
[zebra_fpm]: FIX vrf master device index can't be larger than 255

### DIFF
--- a/zebra/zebra_fpm_netlink.c
+++ b/zebra/zebra_fpm_netlink.c
@@ -327,7 +327,12 @@ static int netlink_route_info_encode(netlink_route_info_t *ri, char *in_buf,
 	req->n.nlmsg_flags = NLM_F_CREATE | NLM_F_REQUEST;
 	req->n.nlmsg_type = ri->nlmsg_type;
 	req->r.rtm_family = ri->af;
-	req->r.rtm_table = ri->rtm_table;
+	if (ri->rtm_table < 256)
+		req->r.rtm_table = ri->rtm_table;
+	else {
+		req->r.rtm_table = RT_TABLE_COMPAT;
+		addattr32(&req->n, in_buf_len, RTA_TABLE, ri->rtm_table);
+	}
 	req->r.rtm_dst_len = ri->prefix->prefixlen;
 	req->r.rtm_protocol = ri->rtm_protocol;
 	req->r.rtm_scope = RT_SCOPE_UNIVERSE;


### PR DESCRIPTION
The existing Frr suite have a bug. When master device index is larger than 255 , index will be truncated to uchar. For vrf support we set master index to another data structure following netlink message definition.