### PR TITLE
Add BGP dynamic capability support for graceful restart

### DIFF
--- a/bgpd/bgp_open.h
+++ b/bgpd/bgp_open.h
@@ -24,7 +24,7 @@
 /* Standard header for capability TLV */
 struct capability_header {
 	uint8_t code;
-	uint8_t length;
+	uint8_t length; /* Note, extra one more oct in dynamic capabilities */
 };
 
 /* Generic MP capability data */
@@ -35,9 +35,14 @@ struct capability_mp_data {
 };
 
 struct graceful_restart_af {
-	afi_t afi;
-	safi_t safi;
+	uint16_t afi;
+	uint8_t safi;
 	uint8_t flag;
+};
+
+struct capability_gr {
+	uint16_t restart_flag_time;
+	struct graceful_restart_af gr[];
 };
 
 /* Capability Code */


### PR DESCRIPTION
When graceful-retart is enabled, trigger graceful restart capability in
BGP capability message, so that neighbors with dynamic capability support
can update graceful restart status, including forwarding state bit for each
address-family without resetting adjacency.