### PR TITLE
fix idx_word

### DIFF
--- a/lib/filter.c
+++ b/lib/filter.c
@@ -2143,7 +2143,7 @@ DEFUN (no_access_list_any,
        "Specify packets to forward\n"
        "Prefix to match. e.g. 10.0.0.0/8\n")
 {
-	int idx_word = 1;
+	int idx_word = 2;
 	int idx = 0;
 	char *seq = NULL;
 	char *permit_deny = NULL;


### PR DESCRIPTION
There is a wrong assignment, when idx_word=1, the entry of access-list WORD [seq (1-4294967295)] <permit|deny> any cannot be deleted.
I fixed.Please review it, thanks.
the wrong output:
```
log syslog notifications
log facility local4
!
enable password zebra
password zebra
!
access-list acl_entry seq 5 permit any
!
line vty
!
router bgp 300
 neighbor 2.1.1.2 remote-as 200
!
end
sonic(config)# end
sonic# show ip access-list 
ZEBRA:
Zebra IP access list acl_entry
    seq 5 permit any
BGP:
Zebra IP access list acl_entry
    seq 5 permit any
STATIC:
Zebra IP access list acl_entry
    seq 5 permit any
sonic# con t
sonic(config)# no access-list acl_entry seq 5 permit any 
  <cr>  
sonic(config)# no access-list acl_entry seq 5 permit any 
sonic(config)# end
sonic# show ip access-list 
ZEBRA:
Zebra IP access list acl_entry
    seq 5 permit any
BGP:
Zebra IP access list acl_entry
    seq 5 permit any
STATIC:
Zebra IP access list acl_entry
    seq 5 permit any
sonic# show running-config access-list 

log syslog notifications
log facility local4
!
access-list acl_entry seq 5 permit any
!
end
```
```
the right output after fixing:
sonic# show ip access-list 
ZEBRA:
BGP:
STATIC:
sonic# 
```
Signed-off-by: yangshiping <yangshiping@jd.com>