### PR TITLE
Perhaps frr.log should be writable by frr itself

### DIFF
--- a/tools/etc/rsyslog.d/45-frr.conf
+++ b/tools/etc/rsyslog.d/45-frr.conf
@@ -2,6 +2,7 @@
 # to /var/log/frr/frr.log, then drops the message so it does
 # not also go to /var/log/syslog, so the messages are not duplicated
 
+$fileOwner frr
 $outchannel frr_log,/var/log/frr/frr.log
 if  $programname == 'babeld' or
     $programname == 'bgpd' or


### PR DESCRIPTION
Creating the frr.log with root as owner, prevents frr itself from writing to that file, in case we want to have frr write to its log directly instead of going though rsyslog.