### PR TITLE
fix bgp local router-id selected error

### DIFF
--- a/lib/if.c
+++ b/lib/if.c
@@ -475,7 +475,14 @@ int if_is_loopback(const struct interface *ifp)
 	/* XXX: Do this better, eg what if IFF_WHATEVER means X on platform M
 	 * but Y on platform N?
 	 */
-	return (ifp->flags & (IFF_LOOPBACK | IFF_NOXMIT | IFF_VIRTUAL));
+#define INSPUR_LO_STR "Loopback"
+    bool is_lo = false;
+    if (strlen(INSPUR_LO_STR) <= strlen(ifp->name)) {
+		if (!strncmp(INSPUR_LO_STR, ifp->name, strlen(INSPUR_LO_STR)))
+		is_lo = true;
+		}
+	
+	return is_lo | (ifp->flags & (IFF_LOOPBACK | IFF_NOXMIT | IFF_VIRTUAL));
 }
 
 /* Check interface is VRF */


### PR DESCRIPTION
Root cause:
    loopback interface is created by "ip link add XXX type dummy"; however, IFF_LOOPBACK flag is not set

Solution:
    check interface name prefix (Loopback) to let zebra use sorted rid_lo list instead of rid_all list