### PR TITLE
lib: check hostname in resolver_resolve

### DIFF
--- a/lib/resolver.c
+++ b/lib/resolver.c
@@ -202,6 +202,9 @@ void resolver_resolve(struct resolver_query *query, int af,
 {
 	int ret;
 
+	if (hostname == NULL)
+		return;
+
 	if (query->callback != NULL) {
 		flog_err(
 			EC_LIB_RESOLVER,


### PR DESCRIPTION
resolver_resolve should check hostname is null or not.

if ares_gethostbyname() get null hostname string, the hostname string will access a null pointer and crash.
**test result:**
![null](https://user-images.githubusercontent.com/57648884/177693893-d7ed392b-761d-4d1b-a606-5fcfb8ab084d.png)

**trace code:**
![log1](https://user-images.githubusercontent.com/57648884/177693878-429fccce-2aa8-4e33-9637-a8ea8a388c0f.png)
![log1-1](https://user-images.githubusercontent.com/57648884/177693884-cef1f1f1-8dbe-45d7-8100-b5b94ed8b378.png)
![log2](https://user-images.githubusercontent.com/57648884/177693890-9a6ad949-ff14-4c90-9840-908f9f0be825.png)


